### PR TITLE
cwd

### DIFF
--- a/src/pid/cwd.rs
+++ b/src/pid/cwd.rs
@@ -1,0 +1,33 @@
+//! Concerning the current working directory of a process, from
+//! `/proc/[pid]/cwd`.
+
+use std::fs;
+use std::io::Result;
+use std::path::PathBuf;
+
+use libc::pid_t;
+
+
+/// Gets path of current working directory for the process with the provided
+/// pid.
+pub fn cwd(pid: pid_t) -> Result<PathBuf> {
+    fs::read_link(format!("/proc/{}/cwd", pid))
+}
+
+
+/// Gets path of current working directory for the current process.
+pub fn cwd_self() -> Result<PathBuf> {
+    fs::read_link(format!("/proc/self/cwd"))
+}
+
+
+#[cfg(test)]
+pub mod tests {
+    use super::cwd_self;
+    use std::env;
+
+    #[test]
+    fn test_cwd_self() {
+        assert_eq!(env::current_dir().unwrap(), cwd_self().unwrap());
+    }
+}

--- a/src/pid/mod.rs
+++ b/src/pid/mod.rs
@@ -1,9 +1,11 @@
 //! Process-specific information from `/proc/[pid]/`.
 
+mod cwd;
 mod stat;
 mod statm;
 mod status;
 
+pub use pid::cwd::{cwd, cwd_self};
 pub use pid::statm::{Statm, statm, statm_self};
 pub use pid::status::{SeccompMode, Status, status, status_self};
 pub use pid::stat::{Stat};


### PR DESCRIPTION
Hi! Here's a "parser" for `/proc/[pid]/cwd` symlinks.

(I don't actually need this for anything right now; it's just that the other day I felt a surge of patriotic enthusiasm for making the Rust ecosystem more mature shortly after happening to come across Python's `psutil`.)
