### PR TITLE
Make tests run on non-nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,12 @@ exclude = [
   ".gitignore",
   ".travis.yml",
 ]
+build = "build.rs"
 
 [dependencies]
 libc = "0.2"
 nom = "1"
 byteorder = "0.5"
+
+[build-dependencies]
+rustc_version = "0.1.7"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+extern crate rustc_version;
+
+use rustc_version::{Channel, version_meta};
+
+fn main() {
+    if let Channel::Nightly = version_meta().channel {
+        println!("cargo:rustc-cfg=rustc_nightly");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![recursion_limit = "1000"]
-#![cfg_attr(test, feature(test))]
+#![cfg_attr(rustc_nightly, feature(test))]
 
 #![allow(dead_code)] // TODO: remove
 

--- a/src/loadavg.rs
+++ b/src/loadavg.rs
@@ -54,12 +54,6 @@ pub fn loadavg() -> Result<LoadAvg> {
 
 #[cfg(test)]
 mod tests {
-
-    extern crate test;
-
-    use std::fs::File;
-
-    use parsers::read_to_end;
     use super::{loadavg, parse_loadavg};
     use parsers::tests::unwrap;
 
@@ -80,6 +74,16 @@ mod tests {
         assert_eq!(625, loadavg.tasks_total);
         assert_eq!(8435, loadavg.last_created_pid);
     }
+}
+
+#[cfg(all(test, rustc_nightly))]
+mod benches {
+    extern crate test;
+
+    use std::fs::File;
+
+    use parsers::read_to_end;
+    use super::{loadavg, parse_loadavg};
 
     #[bench]
     fn bench_loadavg(b: &mut test::Bencher) {

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -216,9 +216,6 @@ macro_rules! take_until_right_and_consume(
 
 #[cfg(test)]
 pub mod tests {
-
-    extern crate test;
-
     use std::u32;
 
     use nom::IResult;

--- a/src/pid/stat.rs
+++ b/src/pid/stat.rs
@@ -319,12 +319,6 @@ pub fn stat_self() -> Result<Stat> {
 
 #[cfg(test)]
 pub mod tests {
-
-    extern crate test;
-
-    use std::fs::File;
-
-    use parsers::read_to_end;
     use parsers::tests::unwrap;
     use pid::State;
     use super::{
@@ -405,6 +399,16 @@ pub mod tests {
         assert_eq!(140736514007019, stat.env_end);
         assert_eq!(0, stat.exit_code);
     }
+}
+
+#[cfg(all(test, rustc_nightly))]
+mod benches {
+    extern crate test;
+
+    use std::fs::File;
+
+    use parsers::read_to_end;
+    use super::{parse_stat, stat};
 
     #[bench]
     fn bench_stat(b: &mut test::Bencher) {

--- a/src/pid/statm.rs
+++ b/src/pid/statm.rs
@@ -60,12 +60,6 @@ pub fn statm_self() -> Result<Statm> {
 
 #[cfg(test)]
 mod tests {
-
-    extern crate test;
-
-    use std::fs::File;
-
-    use parsers::read_to_end;
     use parsers::tests::unwrap;
     use super::{parse_statm, statm, statm_self};
 
@@ -86,6 +80,16 @@ mod tests {
         assert_eq!(330, statm.text);
         assert_eq!(890, statm.data);
     }
+}
+
+#[cfg(all(test, rustc_nightly))]
+mod benches {
+    extern crate test;
+
+    use std::fs::File;
+
+    use parsers::read_to_end;
+    use super::{parse_statm, statm};
 
     #[bench]
     fn bench_statm(b: &mut test::Bencher) {

--- a/src/pid/status.rs
+++ b/src/pid/status.rs
@@ -340,12 +340,6 @@ pub fn status_self() -> Result<Status> {
 
 #[cfg(test)]
 mod tests {
-
-    extern crate test;
-
-    use std::fs::File;
-
-    use parsers::read_to_end;
     use parsers::tests::unwrap;
     use super::{SeccompMode, parse_status, status, status_self};
     use pid::State;
@@ -473,6 +467,16 @@ mod tests {
         assert_eq!(242129, status.voluntary_ctxt_switches);
         assert_eq!(1748, status.nonvoluntary_ctxt_switches);
     }
+}
+
+#[cfg(all(test, rustc_nightly))]
+mod benches {
+    extern crate test;
+
+    use std::fs::File;
+
+    use parsers::read_to_end;
+    use super::{parse_status, status};
 
     #[bench]
     fn bench_status(b: &mut test::Bencher) {


### PR DESCRIPTION
The test modules previously used the unstable test feature for
benchmarks. This moves all benchmarks to sibling `benches` modules, and
uses a build script to only build the module on nightly.