### PR TITLE
stat: Work around stack overflow in rustc

### DIFF
--- a/src/pid/mod.rs
+++ b/src/pid/mod.rs
@@ -11,7 +11,7 @@ pub use pid::status::{SeccompMode, Status, status, status_self};
 pub use pid::stat::{Stat, stat, stat_self};
 
 /// The state of a process.
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum State {
     /// Running.
     Running,


### PR DESCRIPTION
Split up the parsing of /proc/<pid>/stat into two subparsers to limit
AST depth in expanded code. This works around a stack overflow in some
versions of rustc.

There is a performance impact, though a few hundred nanoseconds should
be acceptable in return for working on stable Rust.

    name                  old ns/iter  new ns/iter  diff ns/iter  diff %
    bench_stat            5,240        6,400               1,160  22.14%
    bench_stat_parse      2,132        2,835                 703  32.97%

Benchmarks were run with nightly-2016-10-28, a recent nightly without
the stack overflow issue.

Fixes #9
Refs https://github.com/rust-lang/rust/issues/35408