### PR TITLE
parsers: bump nom to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
-nom = "1"
+nom = { version = "2", features = ["verbose-errors"] }
 byteorder = "0.5"
 
 [build-dependencies]

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -135,7 +135,7 @@ named!(pub parse_f32<f32>,
       map_res!(map_res!(fdigit, str::from_utf8), FromStr::from_str));
 
 /// Parses a sequence of whitespace seperated u32s.
-named!(pub parse_u32s<Vec<u32> >, separated_list!(space, parse_u32));
+named!(pub parse_u32s<Vec<u32> >, separated_list!(space, complete!(parse_u32)));
 
 /// Parses a sequence of whitespace seperated i32s.
 named!(pub parse_i32s<Vec<i32> >, separated_list!(space, parse_i32));


### PR DESCRIPTION
This commit updates parsers to use nom v2. Notes:
 * opting-in "verbose-errors" feature for backward compatibility
 * minor adjustments to `parse_u32s` as `digit` may now return
   `Incomplete` on empty input

For more details, see
https://github.com/Geal/nom/blob/2.0.0/doc/upgrading_to_nom_2.md