### PR TITLE
Added parser for status/no_new_privs

### DIFF
--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -145,17 +145,10 @@ named!(pub parse_u32s<Vec<u32> >, separated_list!(space, complete!(parse_u32)));
 named!(pub parse_i32s<Vec<i32> >, separated_list!(space, parse_i32));
 
 /// Parses a bit into a boolean
-named!(pub parse_bit<bool>,
-    do_parse!(
-        bit: one_of!("01") >>
-
-        (match bit {
-            '1' => true,
-            '0' => false,
-            _ => panic!() // can only be one or 0
-        })
-    )
-);
+named!(pub parse_bit<bool>, alt!(
+          char!('0') => { |_| false }
+        | char!('1') => { |_| true }
+));
 
 /// Parses a usize followed by a kB unit tag.
 named!(pub parse_kb<usize>,

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -144,6 +144,19 @@ named!(pub parse_u32s<Vec<u32> >, separated_list!(space, complete!(parse_u32)));
 /// Parses a sequence of whitespace seperated i32s.
 named!(pub parse_i32s<Vec<i32> >, separated_list!(space, parse_i32));
 
+/// Parses a bit into a boolean
+named!(pub parse_bit<bool>,
+    do_parse!(
+        bit: one_of!("01") >>
+
+        (match bit {
+            '1' => true,
+            '0' => false,
+            _ => panic!() // can only be one or 0
+        })
+    )
+);
+
 /// Parses a usize followed by a kB unit tag.
 named!(pub parse_kb<usize>,
        chain!(space ~ bytes: parse_usize ~ space ~ tag!("kB"), || { bytes }));
@@ -224,7 +237,7 @@ pub mod tests {
 
     use nom::IResult;
 
-    use super::{map_result, parse_f32, parse_i32, parse_i32s, parse_i64, parse_u32_hex,
+    use super::{map_result, parse_f32, parse_i32, parse_i32s, parse_bit, parse_i64, parse_u32_hex,
                 parse_u32_mask_list, parse_u32s, reverse};
 
     /// Unwrap a complete parse result.
@@ -310,5 +323,11 @@ pub mod tests {
         assert_eq!(0.0, unwrap(parse_f32(b"0.0")));
         assert_eq!(2.0, unwrap(parse_f32(b"2.0")));
         assert_eq!(45.67, unwrap(parse_f32(b"45.67")));
+    }
+
+    #[test]
+    fn test_parse_bit() {
+        assert_eq!(true, unwrap(parse_bit(b"1")));
+        assert_eq!(false, unwrap(parse_bit(b"0")));
     }
 }

--- a/src/pid/status.rs
+++ b/src/pid/status.rs
@@ -243,7 +243,7 @@ named!(parse_cap_effective<u64>, delimited!(tag!("CapEff:\t"), parse_u64_hex, li
 named!(parse_cap_bounding<u64>,  delimited!(tag!("CapBnd:\t"), parse_u64_hex, line_ending));
 named!(parse_cap_ambient<u64>,  delimited!(tag!("CapAmb:\t"), parse_u64_hex, line_ending));
 
-named!(parse_no_new_privs<bool>,     delimited!(tag!("NoNewPrivs:\t"),     parse_bit,  line_ending));
+named!(parse_no_new_privs<bool>,       delimited!(tag!("NoNewPrivs:\t"),   parse_bit,           line_ending));
 named!(parse_seccomp<SeccompMode>,     delimited!(tag!("Seccomp:\t"),      parse_seccomp_mode,  line_ending));
 named!(parse_cpus_allowed<Box<[u8]> >, delimited!(tag!("Cpus_allowed:\t"), parse_u32_mask_list, line_ending));
 named!(parse_mems_allowed<Box<[u8]> >, delimited!(tag!("Mems_allowed:\t"), parse_u32_mask_list, line_ending));


### PR DESCRIPTION
The method works and passes all unit tests, although I'm not entirely comfortable with the introduction of a panic to allow it to compile. Logically it should never happen, but I'd still prefer another way if anyone can think of one.

Maybe a better alternative would be to return an error, although I'm not sure of the best way to do this within Nom.

Addresses #20 