### PR TITLE
Add parser for /proc/[pid]/maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ currently the following interfaces are provided:
 * `/proc/loadavg`
 * `/proc/<pid>/cwd`
 * `/proc/<pid>/limits`
+* `/proc/<pid>/maps`
 * `/proc/<pid>/mountinfo`
 * `/proc/<pid>/stat`
 * `/proc/<pid>/statm`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate libc;
 
 #[macro_use]
 mod parsers;
+mod unmangle;
 
 mod loadavg;
 pub mod pid;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -169,6 +169,11 @@ named!(pub parse_u64_hex<u64>,
        map_res!(map_res!(alphanumeric, str::from_utf8),
                 |s| u64::from_str_radix(s, 16)));
 
+/// Parses a usize in base-16 format.
+named!(pub parse_usize_hex<usize>,
+       map_res!(map_res!(alphanumeric, str::from_utf8),
+                |s| usize::from_str_radix(s, 16)));
+
 /// Reverses the bits in a byte.
 fn reverse(n: u8) -> u8 {
     // stackoverflow.com/questions/2602823/in-c-c-whats-the-simplest-way-to-reverse-the-order-of-bits-in-a-byte

--- a/src/pid/maps.rs
+++ b/src/pid/maps.rs
@@ -1,0 +1,243 @@
+//! Process memory mappings information from `/proc/[pid]/maps`.
+
+use std::ffi::OsString;
+use std::io::{self, BufRead};
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+use std::{fs, ops};
+
+use libc;
+use nom::{rest, space};
+
+use parsers::{map_result, parse_usize_hex, parse_u32_hex, parse_u64, parse_u64_hex};
+use unmangle::unmangled_path;
+
+/// Process memory mapping information.
+///
+/// Due to the way paths are encoded by the kernel before exposing them in
+/// `/proc/[pid]/maps`, the parsing of `path` and `is_deleted` is
+/// ambiguous. For example, all the following path/deleted combinations:
+///
+/// - `/tmp/a\nfile` *(deleted file)*
+/// - `/tmp/a\nfile (deleted)` *(existing file)*
+/// - `/tmp/a\\012file` *(deleted file)*
+/// - `/tmp/a\\012file (deleted)` *(existing file)*
+///
+/// will be mangled by the kernel and decoded by this module as:
+///
+/// ```rust,ignore
+/// MemoryMapping (
+///    ...,
+///    path: PathBuf::from("/tmp/a\nfile"),
+///    is_deleted:true,
+/// )
+/// ```
+///
+/// If the `path` of a mapping is required for other than purely informational
+/// uses (such as opening and/or memory mapping it), a more reliable source
+/// (such as `/proc/[pid]/map_files`) should be used, if available. The open
+/// file `(dev, inode)` should also be checked against the values provided by
+/// the mapping.
+///
+/// See `man 5 proc`, `Linux/fs/proc/task_mmu.c`, and `Linux/fs/seq_file.c`.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct MemoryMapping {
+    /// Address range that this mapping occupies in the process virtual memory
+    /// space.
+    pub range: ops::Range<usize>,
+    /// Whether pages in this mapping may be read.
+    pub is_readable: bool,
+    /// Whether pages in this mapping may be written.
+    pub is_writable: bool,
+    /// Whether pages in this mapping may be executed.
+    pub is_executable: bool,
+    /// Whether this mapping is shared.
+    pub is_shared: bool,
+    /// Offset into the file backing this mapping (for non-anonymous mappings).
+    pub offset: u64,
+    /// Device containing the file backing this mapping (for non-anonymous
+    /// mappings).
+    pub dev: libc::dev_t,
+    /// Inode of the file backing this mapping (for non-anonymous mappings).
+    pub inode: libc::ino_t,
+    /// Path to the file backing this mapping (for non-anonymous mappings),
+    /// pseudo-path (such as `[stack]`, `[heap]`, or `[vdso]`) for some special
+    /// anonymous mappings, or empty path for other anonymous mappings.
+    pub path: PathBuf,
+    /// Whether the file backing this mapping has been deleted (for
+    /// non-anonymous mappings).
+    pub is_deleted: bool,
+}
+
+impl MemoryMapping {
+    /// Returns `true` if this is an anonymous mapping.
+    pub fn is_anonymous(&self) -> bool {
+        self.inode == 0
+    }
+}
+
+/// Parsed `pathname` field.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct Pathname {
+    path: PathBuf,
+    is_deleted: bool,
+}
+
+impl Pathname {
+    /// Parses a `pathname` field.
+    fn from_bytes(bytes: &[u8]) -> Self {
+        let mut path = unmangled_path(bytes, b"\n");
+        let deleted_suffix = b" (deleted)";
+        let is_deleted = path.ends_with(deleted_suffix);
+        if is_deleted {
+            let length = path.len() - deleted_suffix.len();
+            path.truncate(length);
+        }
+        Pathname {
+            path: PathBuf::from(OsString::from_vec(path)),
+            is_deleted,
+        }
+    }
+}
+
+/// Parses read permission flag.
+named!(perms_read<&[u8], bool>, map!(one_of!("r-"), |c| c == 'r'));
+
+/// Parses write permission flag.
+named!(perms_write<&[u8], bool>, map!(one_of!("w-"), |c| c == 'w'));
+
+/// Parses execute permission flag.
+named!(perms_execute<&[u8], bool>, map!(one_of!("x-"), |c| c == 'x'));
+
+/// Parses shared/private permission flag.
+named!(perms_shared<&[u8], bool>, map!(one_of!("sp"), |c| c == 's'));
+
+/// Parses a maps entry.
+named!(parse_maps_entry<&[u8], MemoryMapping>, do_parse!(
+    start: parse_usize_hex >> tag!("-") >>
+    end: parse_usize_hex >> space >>
+    is_readable: perms_read >>
+    is_writable: perms_write >>
+    is_executable: perms_execute >>
+    is_shared: perms_shared >> space >>
+    offset: parse_u64_hex >> space >>
+    major: parse_u32_hex >> tag!(":") >>
+    minor: parse_u32_hex >> space >>
+    inode: parse_u64 >> space >>
+    pathname: map!(rest, Pathname::from_bytes) >>
+    (MemoryMapping {
+        range: ops::Range{start, end},
+        is_readable,
+        is_writable,
+        is_executable,
+        is_shared,
+        offset,
+        dev: unsafe {libc::makedev(major, minor)},
+        inode,
+        path: pathname.path,
+        is_deleted: pathname.is_deleted,
+    })
+));
+
+/// Parses the provided maps file.
+fn maps_file<R: io::Read>(file: &mut R) -> io::Result<Vec<MemoryMapping>> {
+    io::BufReader::new(file)
+        .split(b'\n')
+        .map(|line| map_result(parse_maps_entry(&line?)))
+        .collect()
+}
+
+/// Returns mapped memory regions information for the process with the provided
+/// pid.
+pub fn maps(pid: libc::pid_t) -> io::Result<Vec<MemoryMapping>> {
+    maps_file(&mut fs::File::open(format!("/proc/{}/maps", pid))?)
+}
+
+/// Returns mapped memory regions information for the current process.
+pub fn maps_self() -> io::Result<Vec<MemoryMapping>> {
+    maps_file(&mut fs::File::open("/proc/self/maps")?)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    /// Test that the current process maps file can be parsed.
+    #[test]
+    fn test_maps() {
+        maps_self().unwrap();
+    }
+
+    #[test]
+    fn test_maps_file() {
+        let maps_text = b"\
+5643a788f000-5643a7897000 r-xp 00000000 fd:01 8650756      /bin/cat
+7f0540a43000-7f0540a47000 rw-p 00000000 00:00 0 \n";
+        let mut buf = io::Cursor::new(maps_text.as_ref());
+        let maps = maps_file(&mut buf).unwrap();
+        assert_eq!(2, maps.len());
+    }
+
+    #[test]
+    fn test_maps_file_pathname_ends_with_cr() {
+        let maps_text = b"\
+5643a788f000-5643a7897000 r-xp 00000000 fd:01 8650756      /bin/cat\r
+5643a9412000-5643a9433000 rw-p 00000000 00:00 0            [heap]
+";
+        let mut buf = io::Cursor::new(maps_text.as_ref());
+        let maps = maps_file(&mut buf).unwrap();
+        assert_eq!(2, maps.len());
+        assert_eq!(Path::new("/bin/cat\r"), maps[0].path);
+    }
+
+    #[test]
+    fn test_parse_maps_entry() {
+        let maps_entry_text = b"\
+5643a788f000-5643a7897000 r-xp 00000000 fd:01 8650756      /bin/cat";
+
+        let map = parse_maps_entry(maps_entry_text).to_result().unwrap();
+        assert_eq!(0x5643a788f000, map.range.start);
+        assert_eq!(0x5643a7897000, map.range.end);
+        assert!(map.is_readable);
+        assert!(!map.is_writable);
+        assert!(map.is_executable);
+        assert!(!map.is_shared);
+        assert_eq!(0, map.offset);
+        assert_eq!(unsafe { libc::makedev(0xfd, 0x1) }, map.dev);
+        assert_eq!(8650756, map.inode);
+        assert_eq!(Path::new("/bin/cat"), map.path);
+        assert!(!map.is_deleted);
+    }
+
+    #[test]
+    fn test_parse_maps_entry_no_path() {
+        let maps_entry_text = b"\
+7f8ec1d99000-7f8ec1dbe000 rw-p 00000000 00:00 0 ";
+
+        let map = parse_maps_entry(maps_entry_text).to_result().unwrap();
+        assert_eq!(Path::new(""), map.path);
+        assert!(!map.is_deleted);
+        assert!(map.is_anonymous());
+    }
+
+    #[test]
+    fn test_pathname_from_bytes() {
+        let pathname = Pathname::from_bytes(b"/bin/cat");
+        assert_eq!(Path::new("/bin/cat"), pathname.path);
+        assert!(!pathname.is_deleted);
+
+        let pathname = Pathname::from_bytes(b"/bin/cat (deleted)");
+        assert_eq!(Path::new("/bin/cat"), pathname.path);
+        assert!(pathname.is_deleted);
+
+        let pathname = Pathname::from_bytes(br"/bin/a program");
+        assert_eq!(Path::new("/bin/a program"), pathname.path);
+        assert!(!pathname.is_deleted);
+
+        let pathname = Pathname::from_bytes(br"/bin/a\012program");
+        assert_eq!(Path::new("/bin/a\nprogram"), pathname.path);
+        assert!(!pathname.is_deleted);
+    }
+}

--- a/src/pid/maps.rs
+++ b/src/pid/maps.rs
@@ -95,7 +95,7 @@ impl Pathname {
         }
         Pathname {
             path: PathBuf::from(OsString::from_vec(path)),
-            is_deleted,
+            is_deleted: is_deleted,
         }
     }
 }
@@ -126,14 +126,14 @@ named!(parse_maps_entry<&[u8], MemoryMapping>, do_parse!(
     inode: parse_u64 >> space >>
     pathname: map!(rest, Pathname::from_bytes) >>
     (MemoryMapping {
-        range: ops::Range{start, end},
-        is_readable,
-        is_writable,
-        is_executable,
-        is_shared,
-        offset,
+        range: ops::Range{start: start, end: end},
+        is_readable: is_readable,
+        is_writable: is_writable,
+        is_executable: is_executable,
+        is_shared: is_shared,
+        offset: offset,
         dev: unsafe {libc::makedev(major, minor)},
-        inode,
+        inode: inode,
         path: pathname.path,
         is_deleted: pathname.is_deleted,
     })
@@ -161,8 +161,8 @@ pub fn maps_self() -> io::Result<Vec<MemoryMapping>> {
 #[cfg(test)]
 pub mod tests {
     use std::path::Path;
-
-    use super::*;
+    use std::io;
+    use super::{libc, maps_file, maps_self, parse_maps_entry, Pathname};
 
     /// Test that the current process maps file can be parsed.
     #[test]

--- a/src/pid/mod.rs
+++ b/src/pid/mod.rs
@@ -14,7 +14,7 @@ pub use pid::mountinfo::{Mountinfo, mountinfo, mountinfo_self};
 pub use pid::statm::{Statm, statm, statm_self};
 pub use pid::status::{SeccompMode, Status, status, status_self};
 pub use pid::stat::{Stat, stat, stat_self};
-pub use pid::maps::{MemoryMap, maps, maps_self};
+pub use pid::maps::{FileMap, MemoryMap, MemoryMapKind, maps, maps_self};
 
 /// The state of a process.
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/src/pid/mod.rs
+++ b/src/pid/mod.rs
@@ -14,7 +14,7 @@ pub use pid::mountinfo::{Mountinfo, mountinfo, mountinfo_self};
 pub use pid::statm::{Statm, statm, statm_self};
 pub use pid::status::{SeccompMode, Status, status, status_self};
 pub use pid::stat::{Stat, stat, stat_self};
-pub use pid::maps::{maps, maps_self, MemoryMapping};
+pub use pid::maps::{MemoryMap, maps, maps_self};
 
 /// The state of a process.
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/src/pid/mod.rs
+++ b/src/pid/mod.rs
@@ -2,6 +2,7 @@
 
 mod cwd;
 mod limits;
+mod maps;
 mod mountinfo;
 mod stat;
 mod statm;
@@ -13,6 +14,7 @@ pub use pid::mountinfo::{Mountinfo, mountinfo, mountinfo_self};
 pub use pid::statm::{Statm, statm, statm_self};
 pub use pid::status::{SeccompMode, Status, status, status_self};
 pub use pid::stat::{Stat, stat, stat_self};
+pub use pid::maps::{maps, maps_self, MemoryMapping};
 
 /// The state of a process.
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/src/unmangle.rs
+++ b/src/unmangle.rs
@@ -1,0 +1,99 @@
+//! Path unmangling functions.
+//!
+//! Paths included in several files under `/proc` are mangled, i.e., some
+//! characters are replaced by the corresponding octal escape sequence `\nnn`.
+//!
+//! For example, the following files:
+//!
+//! - `/proc/[pid]/maps`
+//! - `/proc/[pid]/smaps`
+//! - `/proc/[pid]/numa_maps`
+//! - `/proc/swaps`
+//!
+//! contain mangled paths.
+//!
+//! This module provides the [`unmangled_path`] function to reverse the
+//! mangling (decoding the escape sequences).
+//!
+//! Note that, unless `\` is included in the set of the escaped characters
+//! (which is *not* the case in any of the previous files), the mangling is
+//! actually non-reversible (i.e., the demangling is ambiguous).
+//!
+//! See `mangle_path` in `Linux/fs/seq_file.c` for details on the mangling
+//! algorithm.
+//!
+//! [`unmangled_path`]: fn.unmangled_path.html
+
+use std::str;
+use std::num::ParseIntError;
+
+/// Converts a bytes slice in a given base to an integer.
+fn u8_from_bytes_radix(bytes: &[u8], radix: u32) -> Result<u8, ParseIntError> {
+    let s = unsafe { str::from_utf8_unchecked(bytes) };
+    u8::from_str_radix(s, radix)
+}
+
+/// Returns an iterator that yields the unmangled representation of `path` as
+/// bytes.
+///
+/// This struct is used by the [`unmangled_path`] function. See its
+/// documentation for more.
+///
+/// [`unmangled_path`]: fn.unmangled_path.html
+struct UnmangledPath<'a> {
+    /// Slice of the source path to be unmangled.
+    path: &'a [u8],
+    /// Escaped chars that should be decoded (e.g., b"\n ").
+    escaped: &'a [u8],
+}
+
+impl<'a> Iterator for UnmangledPath<'a> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.path.len() >= 4 && self.path[0] == b'\\' {
+            if let Ok(c) = u8_from_bytes_radix(&self.path[1..4], 8) {
+                if self.escaped.contains(&c) {
+                    self.path = &self.path[4..];
+                    return Some(c);
+                }
+            }
+        }
+        self.path.split_first().map(|(&c, rest)| {
+            self.path = rest;
+            c
+        })
+    }
+}
+
+/// Returns a `Vec<u8>` containing the unmangled representation of `path`.
+///
+/// Octal escape sequences `\nnn` for characters included in `escaped` are
+/// decoded.
+///
+/// This reverses the escaping done by `mangle_path` in `Linux/fs/seq_file.c`.
+///
+/// # Examples
+///
+/// To decode only escaped newlines (leaving other escaped sequences alone):
+///
+/// ```rust,ignore
+/// let path = unmangled_path(br"a\012\040path", b"\n");
+/// assert_eq!(path, b"a\n\\040path");
+/// ```
+pub fn unmangled_path(path: &[u8], escaped: &[u8]) -> Vec<u8> {
+    UnmangledPath { path, escaped }.collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unmangle_path() {
+        assert_eq!(unmangled_path(b"abcd", b"\n"), b"abcd");
+        assert_eq!(unmangled_path(br"a\012path", b"\n"), b"a\npath");
+        assert_eq!(unmangled_path(br"a\012\040path", b"\n"), b"a\n\\040path");
+        assert_eq!(unmangled_path(br"a\012\040path", b"\n "), b"a\n path");
+    }
+}

--- a/src/unmangle.rs
+++ b/src/unmangle.rs
@@ -82,7 +82,10 @@ impl<'a> Iterator for UnmangledPath<'a> {
 /// assert_eq!(path, b"a\n\\040path");
 /// ```
 pub fn unmangled_path(path: &[u8], escaped: &[u8]) -> Vec<u8> {
-    UnmangledPath { path, escaped }.collect()
+    UnmangledPath {
+        path: path,
+        escaped: escaped,
+    }.collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hi!
This adds support for parsing process memory mappings information from `/proc/[pid]/maps`.