### PR TITLE
Parse thread proc files

### DIFF
--- a/src/pid/limits.rs
+++ b/src/pid/limits.rs
@@ -157,6 +157,7 @@ pub struct Limits {
     pub max_realtime_timeout: Limit<Duration>,
 }
 
+/// Parses the provided limits file.
 fn limits_file(file: &mut File) -> Result<Limits> {
     let mut buf = [0; 2048]; // A typical limits file is about 1350 bytes
     map_result(parse_limits(try!(read_to_end(file, &mut buf))))
@@ -170,6 +171,11 @@ pub fn limits(pid: pid_t) -> Result<Limits> {
 /// Returns resource limit information for the current process.
 pub fn limits_self() -> Result<Limits> {
     limits_file(&mut try!(File::open("/proc/self/limits")))
+}
+
+/// Returns resource limit information from the thread with the provided parent process ID and thread ID.
+pub fn limits_task(process_id: pid_t, thread_id: pid_t) -> Result<Limits> {
+    limits_file(&mut try!(File::open(&format!("/proc/{}/task/{}/limits", process_id, thread_id))))
 }
 
 #[cfg(test)]

--- a/src/pid/mountinfo.rs
+++ b/src/pid/mountinfo.rs
@@ -249,6 +249,11 @@ pub fn mountinfo_self() -> Result<Vec<Mountinfo>> {
     mountinfo_file(&mut try!(File::open("/proc/self/mountinfo")))
 }
 
+/// Returns mounts information from the thread with the provided parent process ID and thread ID.
+pub fn mountinfo_task(process_id: pid_t, thread_id: pid_t) -> Result<Vec<Mountinfo>> {
+    mountinfo_file(&mut try!(File::open(&format!("/proc/{}/task/{}/mountinfo", process_id, thread_id))))
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::{Mountinfo, MountOption, OptionalField, mountinfo, mountinfo_self, parse_mountinfo_entry};

--- a/src/pid/stat.rs
+++ b/src/pid/stat.rs
@@ -317,6 +317,11 @@ pub fn stat_self() -> Result<Stat> {
     stat_file(&mut try!(File::open("/proc/self/stat")))
 }
 
+/// Returns status information from the thread with the provided parent process ID and thread ID.
+pub fn stat_task(process_id: pid_t, thread_id: pid_t) -> Result<Stat> {
+    stat_file(&mut try!(File::open(&format!("/proc/{}/task/{}/stat", process_id, thread_id))))
+}
+
 #[cfg(test)]
 pub mod tests {
     use parsers::tests::unwrap;

--- a/src/pid/statm.rs
+++ b/src/pid/statm.rs
@@ -58,6 +58,11 @@ pub fn statm_self() -> Result<Statm> {
     statm_file(&mut try!(File::open("/proc/self/statm")))
 }
 
+/// Returns memory status information from the thread with the provided parent process ID and thread ID.
+pub fn statm_task(process_id: pid_t, thread_id: pid_t) -> Result<Statm> {
+    statm_file(&mut try!(File::open(&format!("/proc/{}/task/{}/statm", process_id, thread_id))))
+}
+
 #[cfg(test)]
 mod tests {
     use parsers::tests::unwrap;

--- a/src/pid/status.rs
+++ b/src/pid/status.rs
@@ -348,6 +348,11 @@ pub fn status_self() -> Result<Status> {
     status_file(&mut try!(File::open("/proc/self/status")))
 }
 
+/// Returns memory status information from the thread with the provided parent process ID and thread ID.
+pub fn status_task(process_id: pid_t, thread_id: pid_t) -> Result<Status> {
+    status_file(&mut try!(File::open(&format!("/proc/{}/task/{}/status", process_id, thread_id))))
+}
+
 #[cfg(test)]
 mod tests {
     use parsers::tests::unwrap;


### PR DESCRIPTION
Export parsing proc fiels, so we can get thread information, `/proc/[pid]/task/[tid]/...`.
