### PR TITLE
Support for Linux version 5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "procinfo"
 # NB: When modifying, also modify html_root_url in lib.rs.
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/danburkert/procinfo-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![recursion_limit = "1000"]
 #![cfg_attr(rustc_nightly, feature(test))]
 
-#![doc(html_root_url = "https://docs.rs/procinfo/0.4.2")]
+#![doc(html_root_url = "https://docs.rs/procinfo/0.4.3")]
 
 #![allow(dead_code)] // TODO: remove
 


### PR DESCRIPTION
Added support for parsing THP_enabled and Speculation_Store_Bypass found in /proc/<pid>/status for Linux 5.0 and 4.17, respectively.