### PR TITLE
enable to return status task with unrecognized field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 
 rust:
-- 1.13.0
 - stable
 - nightly
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ currently the following interfaces are provided:
 * `/proc/<pid>/status`
 * `/proc/sys/fs/file-max`
 * `/proc/net/dev`
+* `/proc/stat`
 
 `procinfo` requires Rust 1.13 or later.
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -72,6 +72,18 @@ pub fn map_result<T>(result: IResult<&[u8], T>) -> Result<T> {
     }
 }
 
+/// Transforms a `nom` parse result into a io result.
+///
+/// It ignores the bytes that can not be recognized.
+pub fn map_result_ignore_remaining<T>(result: IResult<&[u8], T>) -> Result<T> {
+    match result {
+        IResult::Done(_, val) => Ok(val),
+        IResult::Error(err) => Err(Error::new(ErrorKind::InvalidInput,
+                                              format!("unable to parse input: {:?}", err))),
+        _ => Err(Error::new(ErrorKind::InvalidInput, "unable to parse input")),
+    }
+}
+
 
 /// Recognizes numerical characters: 0-9, and periods: '.'.
 fn fdigit(input: &[u8]) -> IResult<&[u8], &[u8]> {

--- a/src/pid/cpu.rs
+++ b/src/pid/cpu.rs
@@ -99,7 +99,7 @@ named!(parse_cpu_info<Cpu>,
 /// Returns information about cpu line aggregated statistics.
 ///
 /// Very first line `cpu` aggregates the numbers in all of the other "cpuN" lines in `/proc/stat`.
-pub fn cpu_line_aggregated_entry() -> Result<Cpu> {
+fn cpu_line_aggregated_entry() -> Result<Cpu> {
     let data = fs::read_to_string("/proc/stat")?;
     let lines: Vec<&str> = data.lines().collect();
     let cpu_line_info = try!(map_result(parse_cpu_info(lines[0].as_bytes())));

--- a/src/pid/cpu.rs
+++ b/src/pid/cpu.rs
@@ -1,0 +1,157 @@
+use parsers::{map_result, parse_usize};
+use nom::{space};
+
+use std::str::{self, FromStr};
+use std::io::{Result};
+use std::fs;
+use std::cmp;
+use std::ops::Div;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Cpu {
+    /// system ("cpu" line) or the specific CPU ("cpuN" line) spent in various states
+    pub cpuid: String,
+
+    /// Time spent in user mode.
+    pub user: usize,
+
+    /// Time spent in user mode with low priority (nice).
+    pub nice: usize,
+
+    /// Time spent in system mode.
+    pub system: usize,
+
+    /// Time spent in the idle task.  This value should be USER_HZ times the second entry in the /proc/uptime pseudo-file.
+    pub idle: usize,
+
+    /// Time waiting for I/O to complete.  This
+    ///                            value is not reliable, for the following rea‐
+    ///                            sons:
+    ///
+    ///                            1. The CPU will not wait for I/O to complete;
+    ///                               iowait is the time that a task is waiting for
+    ///                               I/O to complete.  When a CPU goes into idle
+    ///                               state for outstanding task I/O, another task
+    ///                               will be scheduled on this CPU.
+    ///
+    ///                            2. On a multi-core CPU, the task waiting for I/O
+    ///                               to complete is not running on any CPU, so the
+    ///                               iowait of each CPU is difficult to calculate.
+    ///
+    ///                            3. The value in this field may decrease in cer‐
+    ///                               tain conditions.
+    pub iowait: usize,
+
+    /// Time servicing interrupts.
+    pub irq: usize,
+
+    /// Time servicing softirqs.
+    pub softirq: usize,
+
+    /// Stolen time, which is the time spent in
+    ///                            other operating systems when running in a virtu‐alized environment
+    pub steal: usize,
+
+    /// Time spent running a virtual CPU for guest operating systems
+    /// under the control of the Linux kernel
+    pub guest: usize,
+
+    /// Time spent running a niced guest
+    /// (virtual CPU for guest operating systems
+    /// under the control of the Linux kernel)
+    pub guest_nice: usize,
+}
+
+
+/// Parses a space-terminated string field in a mountinfo entry
+named!(parse_string_field<String>,
+       map_res!(map_res!(is_not!(" "), str::from_utf8), FromStr::from_str));
+
+/// Parses a cpu line or cpuN line from /proc/stat.
+named!(parse_cpu_info<Cpu>,
+    do_parse!(
+              cpuid: parse_string_field  >> space >>
+              user: parse_usize          >> space >>
+              nice: parse_usize          >> space >>
+              system: parse_usize        >> space >>
+              idle: parse_usize          >> space >>
+              iowait: parse_usize        >> space >>
+              irq: parse_usize           >> space >>
+              softirq: parse_usize       >> space >>
+              steal: parse_usize         >> space >>
+              guest: parse_usize         >> space >>
+              guest_nice: parse_usize    >>
+              (Cpu {
+                            cpuid: cpuid,
+                            user: user,
+                            nice: nice,
+                            system: system,
+                            idle: idle,
+                            iowait: iowait,
+                            irq: irq,
+                            softirq: softirq,
+                            steal: steal,
+                            guest: guest,
+                            guest_nice: guest_nice,
+           } )));
+
+
+/// Returns information about cpu line aggregated statistics.
+///
+/// Very first line `cpu` aggregates the numbers in all of the other "cpuN" lines in `/proc/stat`.
+pub fn cpu_line_aggregated_entry() -> Result<Cpu> {
+    let data = fs::read_to_string("/proc/stat")?;
+    let lines: Vec<&str> = data.lines().collect();
+    let cpu_line_info = try!(map_result(parse_cpu_info(lines[0].as_bytes())));
+    Ok(cpu_line_info)
+}
+
+/// Returns the count of the `cpuN lines`.
+pub fn cpu_count() -> Result<usize> {
+    let data = fs::read_to_string("/proc/stat")?;
+    let lines: Vec<&str> = data.lines().collect();
+    let mut cpus = 0;
+    for line in lines {
+        if line.starts_with("cpu") {
+            cpus += 1;
+        }
+    }
+    Ok(cmp::max(cpus - 1, 1))
+}
+
+pub fn cpu_period() -> Result<usize> {
+    let cpu = cpu_line_aggregated_entry().unwrap();
+    let total_time = cpu.user + cpu.nice + cpu.system + cpu.irq + cpu.softirq +
+                              cpu.idle + cpu.iowait + cpu.steal + cpu.guest + cpu.guest_nice;
+    let cpu_count = cpu_count().unwrap();
+    Ok(total_time.div(cpu_count))
+}
+
+
+#[cfg(test)]
+pub mod tests {
+    pub use pid::cpu::{Cpu};
+    use pid::cpu::parse_cpu_info;
+
+    /// Test parsing a single mountinfo entry (positive check).
+    #[test]
+    fn test_parse_cpu_time_info_entry() {
+        let entry =
+            b"cpu0 49663 0 40234 104757317 542691 4420 39572 0 0 0";
+        let got_mi = parse_cpu_info(entry).unwrap().1;
+        let want_mi = Cpu {
+            cpuid: "cpu0".to_string(),
+            user: 49663,
+            nice: 0,
+            system: 40234,
+            idle: 104757317,
+            iowait: 542691,
+            irq: 4420,
+            softirq: 39572,
+            steal: 0,
+            guest: 0,
+            guest_nice : 0,
+        };
+        assert_eq!(got_mi, want_mi);
+    }
+}

--- a/src/pid/io.rs
+++ b/src/pid/io.rs
@@ -1,0 +1,132 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Concerning the I/O information of a process, from
+//! `/proc/[pid]/io`.
+
+use std::fs::File;
+use std::io::Result;
+
+use libc::pid_t;
+use nom::{
+    IResult,
+    Err,
+    ErrorKind,
+    line_ending,
+    space,
+};
+
+use parsers::{
+    map_result,
+    parse_usize,
+    read_to_end,
+};
+
+/// The I/O information of a process
+#[derive(Debug, Default, PartialEq, Eq, Hash)]
+pub struct Io {
+    pub rchar: usize,
+    pub wchar: usize,
+    pub syscr: usize,
+    pub syscw: usize,
+    pub read_bytes: usize,
+    pub write_bytes: usize,
+    pub cancelled_write_bytes: usize,
+}
+
+named!(opt_space<Option<&[u8]>>, opt!(space));
+named!(parse_rchar<usize>, chain!(tag!("rchar:") ~ opt_space ~ s: parse_usize ~ line_ending, || { s }));
+named!(parse_wchar<usize>, chain!(tag!("wchar:") ~ opt_space ~ s: parse_usize ~ line_ending, || { s }));
+named!(parse_syscr<usize>, chain!(tag!("syscr:") ~ opt_space ~ s: parse_usize ~ line_ending, || { s }));
+named!(parse_syscw<usize>, chain!(tag!("syscw:") ~ opt_space ~ s: parse_usize ~ line_ending, || { s }));
+named!(parse_read_bytes<usize>, chain!(tag!("read_bytes:") ~ opt_space ~ s: parse_usize ~ line_ending, || { s }));
+named!(parse_write_bytes<usize>, chain!(tag!("write_bytes:") ~ opt_space ~ s: parse_usize ~ line_ending, || { s }));
+named!(parse_cancelled_write_bytes<usize>, chain!(tag!("cancelled_write_bytes:") ~ opt_space ~ s: parse_usize ~ line_ending, || { s }));
+
+fn parse_io(mut input: &[u8]) -> IResult<&[u8], Io> {
+    let mut io: Io = Default::default();
+    loop {
+        let original_len = input.len();
+        let (rest, ()) = try_parse!(input,
+            alt!( parse_rchar                 => { |value| io.rchar = value }
+                | parse_wchar                 => { |value| io.wchar = value }
+                | parse_syscr                 => { |value| io.syscr = value }
+                | parse_syscw                 => { |value| io.syscw = value }
+                | parse_read_bytes            => { |value| io.read_bytes = value }
+                | parse_write_bytes           => { |value| io.write_bytes = value }
+                | parse_cancelled_write_bytes => { |value| io.cancelled_write_bytes = value }
+            )
+        );
+        let final_len = rest.len();
+        if final_len == 0 {
+            break IResult::Done(&[], io);
+        } else if original_len == final_len {
+            break IResult::Error(Err::Position(ErrorKind::Tag, rest));
+        }
+        input = rest;
+    }
+}
+
+/// Parses the provided stat file.
+fn io_file(file: &mut File) -> Result<Io> {
+    let mut buf = [0; 256]; // A typical io file is about 100 bytes
+    map_result(parse_io(read_to_end(file, &mut buf)?))
+}
+
+/// Returns I/O information for the process with the provided pid.
+pub fn io(pid: pid_t) -> Result<Io> {
+    io_file(&mut File::open(&format!("/proc/{}/io", pid))?)
+}
+
+/// Returns I/O information for the current process.
+pub fn io_self() -> Result<Io> {
+    io_file(&mut File::open("/proc/self/io")?)
+}
+
+/// Returns I/O information from the thread with the provided parent process ID and thread ID.
+pub fn io_task(process_id: pid_t, thread_id: pid_t) -> Result<Io> {
+    io_file(&mut File::open(&format!("/proc/{}/task/{}/io", process_id, thread_id))?)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use parsers::tests::unwrap;
+    use libc::getpid;
+    use super::{Io, io, io_self, parse_io};
+
+    #[test]
+    fn test_io() {
+        io_self().unwrap();
+        io(unsafe { getpid() }).unwrap();
+    }
+
+    #[test]
+    fn test_parse_io() {
+        let text = b"rchar: 4685194216
+wchar: 2920419824
+syscr: 1687286
+syscw: 708998
+read_bytes: 2938340352
+write_bytes: 2464854016
+cancelled_write_bytes: 592056320
+";
+        let io: Io = unwrap(parse_io(text));
+        assert_eq!(4685194216, io.rchar);
+        assert_eq!(2920419824, io.wchar);
+        assert_eq!(1687286,    io.syscr);
+        assert_eq!(708998,     io.syscw);
+        assert_eq!(2938340352, io.read_bytes);
+        assert_eq!(2464854016, io.write_bytes);
+        assert_eq!(592056320,  io.cancelled_write_bytes);
+    }
+}

--- a/src/pid/mod.rs
+++ b/src/pid/mod.rs
@@ -14,7 +14,7 @@ pub use pid::io::{Io, io, io_self, io_task};
 pub use pid::limits::{Limit, Limits, limits, limits_self, limits_task};
 pub use pid::mountinfo::{Mountinfo, mountinfo, mountinfo_self, mountinfo_task};
 pub use pid::statm::{Statm, statm, statm_self, statm_task};
-pub use pid::status::{SeccompMode, Status, status, status_self, status_task};
+pub use pid::status::{SeccompMode, Status, status, status_self, status_task, status_task_with_tolerance};
 pub use pid::stat::{Stat, stat, stat_self, stat_task};
 pub use pid::cpu::{Cpu, cpu_count, cpu_period};
 

--- a/src/pid/mod.rs
+++ b/src/pid/mod.rs
@@ -16,7 +16,7 @@ pub use pid::mountinfo::{Mountinfo, mountinfo, mountinfo_self, mountinfo_task};
 pub use pid::statm::{Statm, statm, statm_self, statm_task};
 pub use pid::status::{SeccompMode, Status, status, status_self, status_task};
 pub use pid::stat::{Stat, stat, stat_self, stat_task};
-pub use pid::cpu::{Cpu};
+pub use pid::cpu::{Cpu, cpu_count, cpu_period};
 
 /// The state of a process.
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/src/pid/mod.rs
+++ b/src/pid/mod.rs
@@ -1,6 +1,7 @@
 //! Process-specific information from `/proc/[pid]/`.
 
 mod cwd;
+mod io;
 mod limits;
 mod mountinfo;
 mod stat;
@@ -8,11 +9,12 @@ mod statm;
 mod status;
 
 pub use pid::cwd::{cwd, cwd_self};
-pub use pid::limits::{Limit, Limits, limits, limits_self};
-pub use pid::mountinfo::{Mountinfo, mountinfo, mountinfo_self};
-pub use pid::statm::{Statm, statm, statm_self};
-pub use pid::status::{SeccompMode, Status, status, status_self};
-pub use pid::stat::{Stat, stat, stat_self};
+pub use pid::io::{Io, io, io_self, io_task};
+pub use pid::limits::{Limit, Limits, limits, limits_self, limits_task};
+pub use pid::mountinfo::{Mountinfo, mountinfo, mountinfo_self, mountinfo_task};
+pub use pid::statm::{Statm, statm, statm_self, statm_task};
+pub use pid::status::{SeccompMode, Status, status, status_self, status_task};
+pub use pid::stat::{Stat, stat, stat_self, stat_task};
 
 /// The state of a process.
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/src/pid/mod.rs
+++ b/src/pid/mod.rs
@@ -7,6 +7,7 @@ mod mountinfo;
 mod stat;
 mod statm;
 mod status;
+mod cpu;
 
 pub use pid::cwd::{cwd, cwd_self};
 pub use pid::io::{Io, io, io_self, io_task};
@@ -15,6 +16,7 @@ pub use pid::mountinfo::{Mountinfo, mountinfo, mountinfo_self, mountinfo_task};
 pub use pid::statm::{Statm, statm, statm_self, statm_task};
 pub use pid::status::{SeccompMode, Status, status, status_self, status_task};
 pub use pid::stat::{Stat, stat, stat_self, stat_task};
+pub use pid::cpu::{Cpu};
 
 /// The state of a process.
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/src/pid/status.rs
+++ b/src/pid/status.rs
@@ -133,6 +133,8 @@ pub struct Status {
     pub hugetlb_pages: usize,
     /// Process's memory is currently being dumped (since Linux 4.15).
     pub core_dumping: bool,
+    /// Transparent hugepage support enabled (since Linux 5.0).
+    pub thp_enabled: bool,
     /// Number of threads in process containing this thread.
     pub threads: u32,
     /// The number of currently queued signals for this real user ID
@@ -166,6 +168,9 @@ pub struct Status {
     /// This field is provided only if the kernel was built with the
     /// `CONFIG_SECCOMP` kernel configuration option enabled.
     pub seccomp: SeccompMode,
+    /// Provides a means for a process to specify a filter for incoming system calls. 
+    /// (since Linux 4.14, see seccomp(2))
+    pub seccomp_filters: u64,
     /// CPUs on which this process may run (since Linux 2.6.24, see cpuset(7)).
     ///
     /// The slice represents a bitmask in the same format as `BitVec`.
@@ -234,6 +239,7 @@ named!(parse_vm_swap<usize>,        delimited!(tag!("VmSwap:"),       parse_kb, 
 named!(parse_hugetlb_pages<usize>,  delimited!(tag!("HugetlbPages:"), parse_kb, line_ending));
 
 named!(parse_core_dumping<bool>, delimited!(tag!("CoreDumping:\t"), parse_bit, line_ending));
+named!(parse_thp_enabled<bool>, delimited!(tag!("THP_enabled:\t"), parse_bit, line_ending));
 
 named!(parse_threads<u32>, delimited!(tag!("Threads:\t"), parse_u32, line_ending));
 
@@ -251,10 +257,11 @@ named!(parse_cap_effective<u64>, delimited!(tag!("CapEff:\t"), parse_u64_hex, li
 named!(parse_cap_bounding<u64>,  delimited!(tag!("CapBnd:\t"), parse_u64_hex, line_ending));
 named!(parse_cap_ambient<u64>,  delimited!(tag!("CapAmb:\t"), parse_u64_hex, line_ending));
 
-named!(parse_no_new_privs<bool>,       delimited!(tag!("NoNewPrivs:\t"),   parse_bit,           line_ending));
-named!(parse_seccomp<SeccompMode>,     delimited!(tag!("Seccomp:\t"),      parse_seccomp_mode,  line_ending));
-named!(parse_cpus_allowed<Box<[u8]> >, delimited!(tag!("Cpus_allowed:\t"), parse_u32_mask_list, line_ending));
-named!(parse_mems_allowed<Box<[u8]> >, delimited!(tag!("Mems_allowed:\t"), parse_u32_mask_list, line_ending));
+named!(parse_no_new_privs<bool>,       delimited!(tag!("NoNewPrivs:\t"),        parse_bit,             line_ending));
+named!(parse_seccomp<SeccompMode>,     delimited!(tag!("Seccomp:\t"),           parse_seccomp_mode,    line_ending));
+named!(parse_seccomp_filters<u64>,     delimited!(tag!("Seccomp_filters:\t"),   parse_u64_hex,         line_ending));
+named!(parse_cpus_allowed<Box<[u8]> >, delimited!(tag!("Cpus_allowed:\t"),      parse_u32_mask_list,   line_ending));
+named!(parse_mems_allowed<Box<[u8]> >, delimited!(tag!("Mems_allowed:\t"),      parse_u32_mask_list,   line_ending));
 
 named!(parse_cpus_allowed_list<()>, chain!(tag!("Cpus_allowed_list:\t") ~ not_line_ending ~ line_ending, || { () }));
 named!(parse_mems_allowed_list<()>, chain!(tag!("Mems_allowed_list:\t") ~ not_line_ending ~ line_ending, || { () }));
@@ -308,6 +315,7 @@ fn parse_status(i: &[u8]) -> IResult<&[u8], Status> {
                | parse_vm_swap           => { |value| status.vm_swap        = value }
                | parse_hugetlb_pages     => { |value| status.hugetlb_pages  = value }
                | parse_core_dumping      => { |value| status.core_dumping   = value }
+               | parse_thp_enabled      =>  { |value| status.thp_enabled    = value }
 
                | parse_threads              => { |value| status.threads                 = value }
                | parse_sig_queued           => { |(count, max)| { status.sig_queued     = count;
@@ -324,11 +332,12 @@ fn parse_status(i: &[u8]) -> IResult<&[u8], Status> {
                | parse_cap_bounding  => { |value| status.cap_bounding  = value }
                | parse_cap_ambient   => { |value| status.cap_ambient   = value }
 
-               | parse_no_new_privs  => { |value| status.no_new_privs  = value }
-               | parse_seccomp       => { |value| status.seccomp       = value }
-               | parse_cpus_allowed  => { |value| status.cpus_allowed  = value }
+               | parse_no_new_privs     => { |value| status.no_new_privs    = value }
+               | parse_seccomp          => { |value| status.seccomp         = value }
+               | parse_seccomp_filters  => { |value| status.seccomp_filters = value }
+               | parse_cpus_allowed     => { |value| status.cpus_allowed    = value }
                | parse_cpus_allowed_list
-               | parse_mems_allowed  => { |value| status.mems_allowed  = value }
+               | parse_mems_allowed     => { |value| status.mems_allowed    = value }
                | parse_mems_allowed_list
                | parse_voluntary_ctxt_switches    => { |value| status.voluntary_ctxt_switches    = value }
                | parse_nonvoluntary_ctxt_switches => { |value| status.nonvoluntary_ctxt_switches = value }
@@ -408,6 +417,7 @@ mod tests {
                             VmSwap:\t      0 kB\n\
                             HugetlbPages:\t          0 kB\n\
                             CoreDumping:\t0\n\
+                            THP_enabled:\t1\n\
                             Threads:\t1\n\
                             SigQ:\t0/257232\n\
                             SigPnd:\t0000000000000000\n\
@@ -422,6 +432,7 @@ mod tests {
                             CapAmb:\t0000000000000000\n\
                             NoNewPrivs:\t0\n\
                             Seccomp:\t0\n\
+                            Seccomp_filters:\t0\n\
                             Speculation_Store_Bypass:\tthread vulnerable\n\
                             Cpus_allowed:\tffff\n\
                             Cpus_allowed_list:\t0-15\n\
@@ -471,6 +482,7 @@ mod tests {
         assert_eq!(0, status.vm_swap);
         assert_eq!(0, status.hugetlb_pages);
         assert_eq!(false, status.core_dumping);
+        assert_eq!(true, status.thp_enabled);
         assert_eq!(1, status.threads);
         assert_eq!(0, status.sig_queued);
         assert_eq!(257232, status.sig_queued_max);
@@ -486,6 +498,7 @@ mod tests {
         assert_eq!(0x0000000000000000, status.cap_ambient);
         assert_eq!(false, status.no_new_privs);
         assert_eq!(SeccompMode::Disabled, status.seccomp);
+        assert_eq!(0, status.seccomp_filters);
         assert_eq!("thread vulnerable".as_bytes(), status.speculation_store_bypass.as_bytes());
         assert_eq!(&[0xff, 0xff, 0x00, 0x00], &*status.cpus_allowed);
         let mems_allowed: &mut [u8] = &mut [0; 64];

--- a/src/pid/status.rs
+++ b/src/pid/status.rs
@@ -21,6 +21,9 @@ use parsers::{
     parse_u64_hex,
     read_to_end
 };
+
+#[cfg(all(target_os = "android", target_arch = "arm"))]
+use parsers::parse_u16_octal;
 use pid::State;
 
 /// The Secure Computing state of a process.
@@ -175,6 +178,7 @@ pub struct Status {
     pub voluntary_ctxt_switches: u64,
     /// Number of involuntary context switches.
     pub nonvoluntary_ctxt_switches: u64,
+    pub speculation_store_bypass: String,
 }
 
 /// Parse the status state format.
@@ -255,8 +259,9 @@ named!(parse_mems_allowed<Box<[u8]> >, delimited!(tag!("Mems_allowed:\t"), parse
 named!(parse_cpus_allowed_list<()>, chain!(tag!("Cpus_allowed_list:\t") ~ not_line_ending ~ line_ending, || { () }));
 named!(parse_mems_allowed_list<()>, chain!(tag!("Mems_allowed_list:\t") ~ not_line_ending ~ line_ending, || { () }));
 
-named!(parse_voluntary_ctxt_switches<u64>,    delimited!(tag!("voluntary_ctxt_switches:\t"),    parse_u64, line_ending));
-named!(parse_nonvoluntary_ctxt_switches<u64>, delimited!(tag!("nonvoluntary_ctxt_switches:\t"), parse_u64, line_ending));
+named!(parse_speculation_store_bypass<String>, delimited!(tag!("Speculation_Store_Bypass:\t"),   parse_line, line_ending));
+named!(parse_voluntary_ctxt_switches<u64>,     delimited!(tag!("voluntary_ctxt_switches:\t"),    parse_u64,  line_ending));
+named!(parse_nonvoluntary_ctxt_switches<u64>,  delimited!(tag!("nonvoluntary_ctxt_switches:\t"), parse_u64,  line_ending));
 
 /// Parse the status format.
 fn parse_status(i: &[u8]) -> IResult<&[u8], Status> {
@@ -327,6 +332,7 @@ fn parse_status(i: &[u8]) -> IResult<&[u8], Status> {
                | parse_mems_allowed_list
                | parse_voluntary_ctxt_switches    => { |value| status.voluntary_ctxt_switches    = value }
                | parse_nonvoluntary_ctxt_switches => { |value| status.nonvoluntary_ctxt_switches = value }
+               | parse_speculation_store_bypass   => { |value| status.speculation_store_bypass   = value }
             )
         ),
         { |_| { status }})
@@ -335,22 +341,22 @@ fn parse_status(i: &[u8]) -> IResult<&[u8], Status> {
 /// Parses the provided status file.
 fn status_file(file: &mut File) -> Result<Status> {
     let mut buf = [0; 2048]; // A typical status file is about 1000 bytes
-    map_result(parse_status(try!(read_to_end(file, &mut buf))))
+    map_result(parse_status(read_to_end(file, &mut buf)?))
 }
 
 /// Returns memory status information for the process with the provided pid.
 pub fn status(pid: pid_t) -> Result<Status> {
-    status_file(&mut try!(File::open(&format!("/proc/{}/status", pid))))
+    status_file(&mut File::open(&format!("/proc/{}/status", pid))?)
 }
 
 /// Returns memory status information for the current process.
 pub fn status_self() -> Result<Status> {
-    status_file(&mut try!(File::open("/proc/self/status")))
+    status_file(&mut File::open("/proc/self/status")?)
 }
 
 /// Returns memory status information from the thread with the provided parent process ID and thread ID.
 pub fn status_task(process_id: pid_t, thread_id: pid_t) -> Result<Status> {
-    status_file(&mut try!(File::open(&format!("/proc/{}/task/{}/status", process_id, thread_id))))
+    status_file(&mut File::open(&format!("/proc/{}/task/{}/status", process_id, thread_id))?)
 }
 
 #[cfg(test)]
@@ -416,6 +422,7 @@ mod tests {
                             CapAmb:\t0000000000000000\n\
                             NoNewPrivs:\t0\n\
                             Seccomp:\t0\n\
+                            Speculation_Store_Bypass:\tthread vulnerable\n\
                             Cpus_allowed:\tffff\n\
                             Cpus_allowed_list:\t0-15\n\
                             Mems_allowed:\t00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000001\n\
@@ -479,6 +486,7 @@ mod tests {
         assert_eq!(0x0000000000000000, status.cap_ambient);
         assert_eq!(false, status.no_new_privs);
         assert_eq!(SeccompMode::Disabled, status.seccomp);
+        assert_eq!("thread vulnerable".as_bytes(), status.speculation_store_bypass.as_bytes());
         assert_eq!(&[0xff, 0xff, 0x00, 0x00], &*status.cpus_allowed);
         let mems_allowed: &mut [u8] = &mut [0; 64];
         mems_allowed[0] = 0x80;


### PR DESCRIPTION
This PR add new api `status_task_with_tolerance` to handle cases where new fields are added in status file which makes status_task return parse error, such as:

[error="Custom { kind: InvalidInput, error: \"unable to parse whole input, remaining: Ok(\\\"SpeculationIndirectBranch:\\\\tconditional enabled\\\\nCpus_allowed:\\\\tffff\\\\nCpus_allowed_list:\\\\t0-15\\\\nMems_allowed:\\\\t00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000001\\\\nMems_allowed_list:\\\\t0\\\\nvoluntary_ctxt_switches:\\\\t595\\\\nnonvoluntary_ctxt_switches:\\\\t2\\\\n\\\")\" }"]